### PR TITLE
Support Win7 x64 French

### DIFF
--- a/ie9/tools/chocolateyInstall.ps1
+++ b/ie9/tools/chocolateyInstall.ps1
@@ -2,7 +2,9 @@
 $winVersionName = $os.Caption
 $winVer = $os.Version
 $bitType = $os.OSArchitecture
-$is64bit = $os.OSArchitecture -match "64"
+
+$processor = Get-WmiObject Win32_Processor
+$is64bit = $processor.AddressWidth -eq 64
 
 #auto installers
 #$urlToWin7_32bit = "http://view.atdmt.com/action/UMIRF_IE_IE9HP_Win7?href=http://download.microsoft.com/download/8/6/D/86DB5DC9-5706-4A5B-BD46-FFBA6FA67D44/IE9-Windows7-x86-enu.exe"


### PR DESCRIPTION
Fix support for x64 bit on French Win7.

On French Win7, the OSArchitecture is "64 bits" instead of "64-bit", It might be different for other cultures.
