### PR TITLE
Making Ruby Installation Completely Silent

### DIFF
--- a/ruby/tools/chocolateyInstall.ps1
+++ b/ruby/tools/chocolateyInstall.ps1
@@ -14,7 +14,7 @@ try {
   $url = 'http://rubyforge.org/frs/download.php/75848/rubyinstaller-1.9.3-p125.exe'
 
   $rubyPath = join-path $binRoot $('ruby' + "$rubyFolder")
-  $silentArgs = "/silent /dir=`"$rubyPath`" /tasks=`"assocfiles,modpath`""
+  $silentArgs = "/verysilent /dir=`"$rubyPath`" /tasks=`"assocfiles,modpath`""
 
   Install-ChocolateyPackage 'ruby' 'exe' "$silentArgs" "$url"
 


### PR DESCRIPTION
The Ruby installation was showing the "Extracting Files" dialog. Changing the flag to "/verysilent" to ensure this doesn't happen.

Rubyinstaller docs:

https://github.com/oneclick/rubyinstaller/wiki/faq#wiki-silent_install
