### PR TITLE
Update sumatrapdf to v2.3.2

### DIFF
--- a/sumatrapdf.commandline/sumatrapdf.commandline.nuspec
+++ b/sumatrapdf.commandline/sumatrapdf.commandline.nuspec
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>sumatrapdf.commandline</id>
     <title>Sumatra PDF (CommandLine)</title>
-    <version>2.2</version>
+    <version>2.3.2</version>
     <authors>Krzysztof Kowalczyk</authors>
     <owners>Rob Reynolds</owners>
     <summary>Sumatra PDF is a free PDF, eBook (ePub, Mobi), XPS, DjVu, CHM, Comic Book (CBZ and CBR) reader for Windows.</summary>

--- a/sumatrapdf.commandline/tools/chocolateyInstall.ps1
+++ b/sumatrapdf.commandline/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyZipPackage 'sumatrapdf.commandline' 'https://kjkpub.s3.amazonaws.com/sumatrapdf/rel/SumatraPDF-2.2.zip' "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+﻿Install-ChocolateyZipPackage 'sumatrapdf.commandline' 'https://kjkpub.s3.amazonaws.com/sumatrapdf/rel/SumatraPDF-2.3.2.zip' "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/sumatrapdf.install/sumatrapdf.install.nuspec
+++ b/sumatrapdf.install/sumatrapdf.install.nuspec
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>sumatrapdf.install</id>
     <title>Sumatra PDF (Install)</title>
-    <version>2.2</version>
+    <version>2.3.2</version>
     <authors>Krzysztof Kowalczyk</authors>
     <owners>Rob Reynolds</owners>
     <summary>Sumatra PDF is a free PDF, eBook (ePub, Mobi), XPS, DjVu, CHM, Comic Book (CBZ and CBR) reader for Windows.</summary>

--- a/sumatrapdf.install/tools/chocolateyInstall.ps1
+++ b/sumatrapdf.install/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyPackage 'sumatrapdf.install' 'exe' '/S' 'https://kjkpub.s3.amazonaws.com/sumatrapdf/rel/SumatraPDF-2.2-install.exe' -validExitCodes @(0)
+﻿Install-ChocolateyPackage 'sumatrapdf.install' 'exe' '/S' 'https://kjkpub.s3.amazonaws.com/sumatrapdf/rel/SumatraPDF-2.3.2-install.exe' -validExitCodes @(0)

--- a/sumatrapdf/sumatrapdf.nuspec
+++ b/sumatrapdf/sumatrapdf.nuspec
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>sumatrapdf</id>
     <title>Sumatra PDF</title>
-    <version>2.2</version>
+    <version>2.3.2</version>
     <authors>Krzysztof Kowalczyk</authors>
     <owners>Rob Reynolds</owners>
     <summary>Sumatra PDF is a free PDF, eBook (ePub, Mobi), XPS, DjVu, CHM, Comic Book (CBZ and CBR) reader for Windows.</summary>
@@ -18,7 +18,7 @@ Simplicity of the user interface has a high priority</description>
     <licenseUrl>http://www.gnu.org/licenses/gpl.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="sumatrapdf.commandline" version="[2.2]" />
+      <dependency id="sumatrapdf.commandline" version="[2.3.2]" />
     </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>


### PR DESCRIPTION
This updates sumatrapdf to v2.3.2 and changes the character encoding of the nuspec files to UTF-8 (ANSI is deprecated).
I’ve sent you a few other pull requests. It would be great if you could merge them too.
Thanks.
