### PR TITLE
Remove slash from packageName argument

### DIFF
--- a/easy.install/tools/chocolateyInstall.ps1
+++ b/easy.install/tools/chocolateyInstall.ps1
@@ -67,7 +67,7 @@ function Install-setuptools($version) {
   else {  
     # http://pypi.python.org/packages/2.7/s/setuptools/setuptools-0.6c11.win32-py2.7.exe
 	$url = "http://pypi.python.org/packages/$pyvrs/s/setuptools/setuptools-$version.win32-py$pyvrs.exe"
-	Install-ChocolateyPackage 'easy.install/setuptools' 'exe' '/S' $url	
+	Install-ChocolateyPackage 'easy.install.setuptools' 'exe' '/S' $url	
   }
 }
 


### PR DESCRIPTION
Chocolatey v0.9.8.20 on Windows 7 gives me this error when installing easy.install:

[ERROR] Exception calling ".ctor" with "2" argument(s): "Could not find a part of the path 'C:\Users\Ph\AppData\Local\Temp\chocolatey\easy.install\setuptools\easy.install\setuptoolsInstall.exe'."

If I hack the install script like this, it will install successfully (but I don't know if that's really the right fix...).  Also, perhaps this is some edge case of my machine's setup, I haven't invested time into reproducing it elsewhere.
