### PR TITLE
Updated to Vim 7.4

### DIFF
--- a/vim/tools/chocolateyInstall.ps1
+++ b/vim/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 $packageName = 'vim'
 $fileType = 'exe'
 $args = '/S'
-$url = 'http://downloads.sourceforge.net/project/cream/Vim/7.3.829/gvim-7-3-829.exe'
+$url = 'ftp://ftp.vim.org/pub/vim/pc/gvim74.exe'
 
 Install-ChocolateyPackage $packageName $fileType $args $url
 

--- a/vim/tools/chocolateyPostInstallUAC.ps1
+++ b/vim/tools/chocolateyPostInstallUAC.ps1
@@ -3,13 +3,7 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 # Attention people from the future. This function will be built into chocolatey 0.9.8.21 or possibly 0.9.8.20
 . (Join-Path $scriptDir '.\Invoke-GenerateBinFile.ps1')
 
-$is64bit = (Get-WmiObject Win32_Processor).AddressWidth -eq 64
-if ($is64bit) {
-      $installDir = Split-Path -Parent (Get-ItemProperty HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Vim UninstallString).UninstallString
-}
-else{
-      $installDir = Split-Path -Parent (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Vim UninstallString).UninstallString
-    }
+$installDir = Split-Path -Parent (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Vim 7.4" UninstallString).UninstallString
 
 $binDir = Join-Path (Split-Path -Parent $installDir) 'bin'
 

--- a/vim/vim.nuspec
+++ b/vim/vim.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>vim</id>
     <title>Vim</title>
-    <version>7.3.8297</version>
+    <version>7.4.0</version>
     <authors>Bram Moolenaar, Vim Community</authors>
     <owners>Rob Reynolds</owners>
     <summary>Vim is an advanced text editor that seeks to provide the power of the de-facto Unix editor 'Vi', with a more complete feature set. It's useful whether you're already using vi or using a different editor.</summary>
     <description>Vim is a highly configurable text editor built to enable efficient text editing. It is an improved version of the vi editor distributed with most UNIX systems.
     Vim is often called a programmer's editor, and so useful for programming that many consider it an entire IDE. It's not just for programmers, though. Vim is perfect for all kinds of text editing, from composing email to editing configuration files.</description>
-    <releaseNotes>Updated to version 7.3.829. Fixed issue installing on 32bit Windows 7</releaseNotes>
+    <releaseNotes>Updated to version 7.4.0.</releaseNotes>
     <projectUrl>http://vim.org</projectUrl>
     <tags>vim editor vi admin</tags>
     <licenseUrl>http://vimdoc.sourceforge.net/htmldoc/uganda.html</licenseUrl>


### PR DESCRIPTION
It appears that this installer now writes to the 64-bit registry, so the ps code checking the architecture is not longer necessary. Note that `cinst vim` must be run from 64-bit cmd or 64-bit powershell for it to work correctly.

Also, despite passing /S, this installer is still a bit noisy. Shows two Y/N dialogs during the install. I couldn't find a way to disable those.

Tested on 64-bit Windows 7.
