### PR TITLE
Fixed bug in Microsoft.Application.targets with extensionless files

### DIFF
--- a/PublishedApplications/content/targets/Microsoft.Application.targets
+++ b/PublishedApplications/content/targets/Microsoft.Application.targets
@@ -226,11 +226,11 @@ Copyright (C) 2005 Microsoft Corporation. All rights reserved.
   <Target Name ="_BuiltExeOutputGroupOutput"
           Condition="!$(Disable_CopyExeApplication)"
           Outputs="@(BuiltExeOutputGroupOutput)">
-    <CreateItem Include="$(ExeProjectOutputDir)\bin\**\*.*;@(Content->'%(FullPath)')" Condition="'$(OutDir)' == '$(OutputPath)'">
+    <CreateItem Include="$(ExeProjectOutputDir)\bin\**\*;@(Content->'%(FullPath)')" Condition="'$(OutDir)' == '$(OutputPath)'">
       <Output ItemName="BuiltExeOutputGroupOutput" TaskParameter="Include"/>
     </CreateItem>
 
-    <CreateItem Include="$(ExeProjectOutputDir)\**\*.*" Condition="'$(OutDir)' != '$(OutputPath)'">
+    <CreateItem Include="$(ExeProjectOutputDir)\**\*" Condition="'$(OutDir)' != '$(OutputPath)'">
       <Output ItemName="BuiltExeOutputGroupOutput" TaskParameter="Include"/>
     </CreateItem>
   </Target>


### PR DESCRIPTION
There is a following bug in Microsoft.Application.targets (the same in its origin - Microsoft.Web.targets):

If you add a file without extension (e.q. "a", "b" instead of "a.cs", "b.txt") as "Content" to your project in VS - it will not be copied to _PublishedPallication. This is a fix for the bug.
