### PR TITLE
Fix App Config transformations in TFS

### DIFF
--- a/PublishedApplications/content/targets/Microsoft.Application.targets
+++ b/PublishedApplications/content/targets/Microsoft.Application.targets
@@ -41,16 +41,9 @@ Copyright (C) 2005 Microsoft Corporation. All rights reserved.
   <!--***************************************************************-->
   <!--App.config -->
   <!--***************************************************************-->
-  <PropertyGroup>
-    <ProjectConfigFileName Condition="'$(ProjectConfigFileName)'==''">app.config</ProjectConfigFileName>
-  </PropertyGroup>
-  <ItemGroup>
-    <!--a item collection such that we can get the file name and extension from it-->
-    <AppConfigFileName Include="$(ProjectConfigFileName)" />
-  </ItemGroup>
   <Target Name="CopyAndRenameAppConfig">
-    <Copy SourceFiles="@(AppConfigFileName)"
-      DestinationFiles="@(AppConfigFileName->'$(ExeProjectOutputDir)\$(AssemblyName).exe%(Extension)')"
+    <Copy SourceFiles="@(AppConfigWithTargetPath)"
+      DestinationFiles="@(AppConfigWithTargetPath->'$(ExeProjectOutputDir)\$(AssemblyName).exe%(Extension)')"
       Retries="$(CopyRetryCount)"
       RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)" 
       Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')"


### PR DESCRIPTION
App config transformations from SlowCheetah or the XmlTransform task would be overwritten with the vanilla app.config. This small change will take the transformed config file.
