### PR TITLE
typescript.vs installer incorrectly set as msi instead of exe

### DIFF
--- a/typescript.vs/tools/chocolateyInstall.ps1
+++ b/typescript.vs/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyPackage 'typescript.vs' 'msi' '/quiet' 'http://download.microsoft.com/download/2/F/F/2FFA1FBA-97CA-4FFB-8ED7-A4AE06398948/TypeScriptSetup.0.9.1.1.exe' -validExitCodes @(0)
+﻿Install-ChocolateyPackage 'typescript.vs' 'exe' '/quiet' 'http://download.microsoft.com/download/2/F/F/2FFA1FBA-97CA-4FFB-8ED7-A4AE06398948/TypeScriptSetup.0.9.1.1.exe' -validExitCodes @(0)


### PR DESCRIPTION
The chocolatey package was returning error 1602 on installation. It
looks like the most recent release switched from being an msi to an exe.
The url was updated but the fileType parameter was not updated.
