### PR TITLE
updates webpicommandline to latest version which does not require .net 3...

### DIFF
--- a/webpicommandline/tools/chocolateyInstall.ps1
+++ b/webpicommandline/tools/chocolateyInstall.ps1
@@ -1,1 +1,3 @@
-Install-ChocolateyZipPackage 'webpicommandline' 'http://go.microsoft.com/fwlink/?LinkId=233753' "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+Install-ChocolateyPackage 'WebPICommandline' 'msi' '/passive /norestart' `
+    'http://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller_x86_en-US.msi'     `
+    'http://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller_amd64_en-US.msi'

--- a/webpicommandline/webpicommandline.nuspec
+++ b/webpicommandline/webpicommandline.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>webpicommandline</id>
     <title>WebPICommandLine</title>
-    <version>7.1.1374.20120226</version>
+    <version>7.1.40719.0</version>
     <authors>Microsoft</authors>
     <owners>Rob Reynolds</owners>
     <summary>Web PI Command Line</summary>


### PR DESCRIPTION
was playing with some webpi on windows 8.1 (which does not come with .net 3.5 installed) and after installing webpicommandline from chocolatey, I was prompted to install .net3.5. Upgrading to this version avoids that.
