### PR TITLE
Updated to 1.4.0.74 (latest) of MSBuild.Community.Tasks.

### DIFF
--- a/msbuild.communitytasks/msbuild.communitytasks.nuspec
+++ b/msbuild.communitytasks/msbuild.communitytasks.nuspec
@@ -3,17 +3,16 @@
   <metadata>
     <id>msbuild.communitytasks</id>
     <title>MSBuild Community Tasks</title>
-    <version>1.2.0.307</version>
+    <version>1.4.0.74</version>
     <authors>Paul Welter</authors>
     <owners>Rob Reynolds</owners>
     <summary>MSBuild Community Tasks - Open Source MSBuild Tasks</summary>
     <description>The MSBuild Community Tasks Project is an open source project for MSBuild tasks. The goal of the project is to provide a collection of open source tasks for MSBuild.</description>
-    <projectUrl>http://msbuildtasks.tigris.org/</projectUrl>
+    <projectUrl>https://github.com/loresoft/msbuildtasks</projectUrl>
     <tags>msbuild.communitytasks msbuild admin</tags>
-    <licenseUrl>http://opensource.org/licenses/bsd-license.php</licenseUrl>
+    <licenseUrl>https://github.com/loresoft/msbuildtasks</licenseUrl>
+    <copyright>Copyright (c) 2012, LoreSoft All rights reserved.  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.  Neither the name of LoreSoft nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  </copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies />
   </metadata>
-  <files>
-    <file src="tools\**" target="tools" />
-  </files>
 </package>

--- a/msbuild.communitytasks/tools/chocolateyInstall.ps1
+++ b/msbuild.communitytasks/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-Install-ChocolateyPackage 'msbuild.communitytasks' 'msi' '/quiet' 'http://www.tigris.org/files/documents/3383/28296/MSBuild.Community.Tasks.msi'
+Install-ChocolateyPackage 'msbuild.communitytasks' 'msi' '/quiet' 'https://github.com/loresoft/msbuildtasks/releases/download/v1.4.0.74/MSBuild.Community.Tasks.v1.4.0.74.msi'


### PR DESCRIPTION
Removed the files tag from the nuspec - this makes the package an 'external package' (as it has content) and means other external packages (i.e. most Chocolatey packages) can depend on it without hitting this problem: http://nuget.codeplex.com/workitem/595.
Included LoreSoft's copyright statement (see https://github.com/loresoft/msbuildtasks).
