### PR TITLE
Update Microsoft.Application.targets file to copy content from referenced assemblies to the correct target directory under the OutDir.

### DIFF
--- a/PublishedApplications/content/targets/Microsoft.Application.targets
+++ b/PublishedApplications/content/targets/Microsoft.Application.targets
@@ -195,13 +195,14 @@ Copyright (C) 2005 Microsoft Corporation. All rights reserved.
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"/>
 
     <!-- Copy items that have been marked to be copied to the bin folder -->
+    <!-- Honor the content from referenced assemblies-->
     <Copy SourceFiles="@(_SourceItemsToCopyToOutputDirectory)"
-          DestinationFolder="$(ExeProjectOutputDir)"
+          DestinationFiles="@(_SourceItemsToCopyToOutputDirectory -> '$(ExeProjectOutputDir)\%(TargetPath)')"          
           SkipUnchangedFiles="true"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"/>
     <Copy SourceFiles="@(_SourceItemsToCopyToOutputDirectoryAlways)"
-          DestinationFolder="$(ExeProjectOutputDir)"
+          DestinationFiles="@(_SourceItemsToCopyToOutputDirectoryAlways -> '$(ExeProjectOutputDir)\%(TargetPath)')"
           SkipUnchangedFiles="false"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"/>


### PR DESCRIPTION
Fix for issue #121 PublishedApplications: Content from referenced assemblies copied to incorrect output directory.